### PR TITLE
Update kdyby/doctrine version constraint to semantic version operator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"nette/forms": "~2.3@dev",
 		"nette/reflection": "~2.3@dev",
 		"kdyby/annotations": "~2.3@dev",
-		"kdyby/doctrine": "v3.0.0"
+		"kdyby/doctrine": "^3.0"
 	},
 	"require-dev": {
 		"nette/application": "~2.3@dev",


### PR DESCRIPTION
This pull request updates the version constraint for `kdyby/doctrine` library to semantic version operator, so we can use it with newer version, not just fixed 3.0.0

Could you please also create new tag and update packagist, if you merge this PR?
